### PR TITLE
Update gerbil

### DIFF
--- a/druix/packages/scheme/gerbil.scm
+++ b/druix/packages/scheme/gerbil.scm
@@ -89,6 +89,7 @@
           (lambda*
            (#:key inputs #:allow-other-keys)
            (setenv "HOME" (getcwd))
+           (setenv "CC" (file-append gcc-toolchain "bin/gcc"))
              (invoke
               ;; The build script needs a tty or it'll crash on an ioctl
               ;; trying to find the width of the terminal it's running on.

--- a/druix/versions/gerbil.scm
+++ b/druix/versions/gerbil.scm
@@ -7,6 +7,28 @@
       #:major
       0
       #:minor
+      0
+      #:patch
+      #f
+      #:revision
+      66
+      #:ymd
+      20220926
+      #:hms
+      181637
+      #:sha256
+      "1712ncdrlnrl77pcln2s0cd97ad7ns1x3p3yygdgh4d99061p5hp"
+      #:repo
+      "ssh://git@github.com/vyzo/gerbil.git"
+      #:commit
+      "605e6fd6003ae8a188ecdbc0406ff682c77f9252")
+
+    (make <druix-version-git>
+      #:name
+      "gerbil"
+      #:major
+      0
+      #:minor
       17
       #:patch
       #f


### PR DESCRIPTION
Create a new version for gerbil-unstable.

Export CC=gcc while building, because the latest gcc-toolchain doesn't have an alias cc for gcc anymore.
